### PR TITLE
Add torch.random.fork_rng

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -50,15 +50,16 @@ dtype = torch.float16
 dtype_vae = torch.float16
 
 def randn(seed, shape):
-    # Pytorch currently doesn't handle setting randomness correctly when the metal backend is used.
-    if device.type == 'mps':
-        generator = torch.Generator(device=cpu)
-        generator.manual_seed(seed)
-        noise = torch.randn(shape, generator=generator, device=cpu).to(device)
-        return noise
+    with torch.random.fork_rng(devices=[device]):
+        # Pytorch currently doesn't handle setting randomness correctly when the metal backend is used.
+        if device.type == 'mps':
+            generator = torch.Generator(device=cpu)
+            generator.manual_seed(seed)
+            noise = torch.randn(shape, generator=generator, device=cpu).to(device)
+            return noise
 
-    torch.manual_seed(seed)
-    return torch.randn(shape, device=device)
+        torch.manual_seed(seed)
+        return torch.randn(shape, device=device)
 
 
 def randn_without_seed(shape):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -344,7 +344,8 @@ def create_random_tensors(shape, seeds, subseeds=None, subseed_strength=0.0, see
             cnt = p.sampler.number_of_needed_noises(p)
 
             if opts.eta_noise_seed_delta > 0:
-                torch.manual_seed(seed + opts.eta_noise_seed_delta)
+                with torch.random.fork_rng(devices=[device]):
+                    torch.manual_seed(seed + opts.eta_noise_seed_delta)
 
             for j in range(cnt):
                 sampler_noises[j].append(devices.randn_without_seed(tuple(noise_shape)))


### PR DESCRIPTION
torch.manual_seed fixes the rng state after its execution, which lead to problems like [#3803](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3803)

This patch fixes it by wrapping torch.manual_seed inside torch.random.fork_rng, so that the rng state is changed within the code block.

![proof](https://user-images.githubusercontent.com/116745066/200914158-eccd3569-ccd8-40f1-8036-c04f0a44f553.PNG)
